### PR TITLE
Implement the trivial-pmda also as perl daemon

### DIFF
--- a/src/pmdas/trivial/GNUmakefile
+++ b/src/pmdas/trivial/GNUmakefile
@@ -35,7 +35,7 @@ include $(BUILDRULES)
 
 install install_pcp:	default
 	$(INSTALL) -m 755 -d $(PMDADIR)
-	$(INSTALL) -m 755 Install Remove $(PMDADIR)
+	$(INSTALL) -m 755 Install Remove pmdatrivial.perl $(PMDADIR)
 	$(INSTALL) -m 644 GNUmakefile.install $(PMDADIR)/Makefile
 	$(INSTALL) -m 644 $(DFILES) root help pmns domain.h $(CFILES) $(PMDADIR)
 

--- a/src/pmdas/trivial/Install
+++ b/src/pmdas/trivial/Install
@@ -21,6 +21,8 @@
 iam=trivial
 pmda_interface=2
 
+perl_opt=true
+
 pmdaSetup
 pmdaInstall
 exit

--- a/src/pmdas/trivial/README
+++ b/src/pmdas/trivial/README
@@ -2,14 +2,14 @@ Trivial PMDA
 ============
 
 This PMDA is a sample that illustrates how a simple PMDA might be
-constructed using libpcp_pmda.
+constructed using libpcp_pmda, or using perl.
 
 Although the metrics supported as simple, the framework is quite
 general, and could be extended to implement a much more complex PMDA.
 
 Note:
-	This PMDA may be remade from source and hence requires a C
-	compiler to be installed.
+	The C variant of this PMDA may be remade from source and hence 
+	requires a C compiler to be installed.
 
 	Uses of make(1) may fail (without removing or clobbering files)
 	if the C compiler cannot be found.  This is most likely to
@@ -43,8 +43,8 @@ Installation
 
 	# ./Install
 
-    and choose both the "collector" and "monitor" installation
-    configuration options -- everything else is automated.
+    and choose between the PMDA variants 'daemon' (the C PMDA) and 
+    'perl' configuration options -- everything else is automated.
 
 De-installation
 ===============

--- a/src/pmdas/trivial/pmdatrivial.perl
+++ b/src/pmdas/trivial/pmdatrivial.perl
@@ -1,0 +1,45 @@
+#!/usr/bin/perl
+#
+# Copyright (c) 2012 Red Hat.
+# Copyright (c) 2008,2012 Aconex.  All Rights Reserved.
+# Copyright (c) 2004 Silicon Graphics, Inc.  All Rights Reserved.
+# 
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation; either version 2 of the License, or (at your
+# option) any later version.
+# 
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+# or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# for more details.
+# 
+
+use strict;
+use warnings;
+use PCP::PMDA;
+
+use vars qw( $pmda );
+my ( $now_indom ) = ( 1 );
+
+sub simple_fetch_callback	# must return array of value,status
+{
+	my ($cluster, $item, $inst) = @_;
+
+	if ($cluster == 0 && $item == 0) { return (time(), 1); }
+	return (PM_ERR_PMID, 0);
+}
+
+
+$pmda = PCP::PMDA->new('trivial', 250);
+$pmda->connect_pmcd;
+
+$pmda->add_metric(pmda_pmid(0,0), PM_TYPE_U32, PM_INDOM_NULL,
+		  PM_SEM_INSTANT, pmda_units(0,0,0,0,0,0),
+		  'trivial.time', '', '');
+
+$now_indom = $pmda->add_indom($now_indom, {}, '', ''); # initialized on-the-fly
+$pmda->set_fetch_callback( \&simple_fetch_callback );
+
+$pmda->set_user('pcp');
+$pmda->run;


### PR DESCRIPTION
The trivial-pmda is currently the most simple pmda implementation, provided in C. Adding a perl variant which provides the same functionality.